### PR TITLE
Add Redis-backed board page with suspense

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,0 +1,64 @@
+import { Suspense } from 'react'
+import { unstable_cache } from 'next/cache'
+
+import { KanbanColumn } from '@/components'
+import type { KanbanItem } from '@/components/KanbanColumn'
+import { redis } from '@/lib/redis'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+interface BoardState {
+  todo: KanbanItem[]
+  progress: KanbanItem[]
+  done: KanbanItem[]
+}
+
+const getBoard = unstable_cache(async () => {
+  const data = await redis.get<BoardState>('board')
+  if (data) return data
+  return { todo: [], progress: [], done: [] }
+}, ['board'])
+
+async function Board() {
+  const board = await getBoard()
+  return (
+    <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
+      <KanbanColumn title="Todo" items={board.todo} onDrop={() => {}} />
+      <KanbanColumn title="In Progress" items={board.progress} onDrop={() => {}} />
+      <KanbanColumn title="Done" items={board.done} onDrop={() => {}} />
+    </main>
+  )
+}
+
+function ColumnSkeleton() {
+  return (
+    <Card className="bg-muted/50">
+      <CardHeader className="p-4 border-b">
+        <CardTitle className="text-sm font-medium">
+          <span className="opacity-0">Loading</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-4">
+        <div className="h-20 rounded-md bg-muted animate-pulse" />
+      </CardContent>
+    </Card>
+  )
+}
+
+function BoardSkeleton() {
+  return (
+    <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
+      <ColumnSkeleton />
+      <ColumnSkeleton />
+      <ColumnSkeleton />
+    </main>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<BoardSkeleton />}>
+      {/* @ts-expect-error Async Server Component */}
+      <Board />
+    </Suspense>
+  )
+}

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -57,7 +57,6 @@ function BoardSkeleton() {
 export default function Page() {
   return (
     <Suspense fallback={<BoardSkeleton />}>
-      {/* @ts-expect-error Async Server Component */}
       <Board />
     </Suspense>
   )

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { unstable_cache } from 'next/cache'
 
-import { KanbanColumn } from '@/components'
+import { BoardClient } from '@/components'
 import type { KanbanItem } from '@/components/KanbanColumn'
 import { redis } from '@/lib/redis'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -13,20 +13,19 @@ interface BoardState {
 }
 
 const getBoard = unstable_cache(async () => {
-  const data = await redis.get<BoardState>('board')
-  if (data) return data
+  if (!redis) return { todo: [], progress: [], done: [] }
+  try {
+    const data = await redis.get<BoardState>('board')
+    if (data) return data
+  } catch {
+    return { todo: [], progress: [], done: [] }
+  }
   return { todo: [], progress: [], done: [] }
 }, ['board'])
 
 async function Board() {
   const board = await getBoard()
-  return (
-    <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-      <KanbanColumn title="Todo" items={board.todo} onDrop={() => {}} />
-      <KanbanColumn title="In Progress" items={board.progress} onDrop={() => {}} />
-      <KanbanColumn title="Done" items={board.done} onDrop={() => {}} />
-    </main>
-  )
+  return <BoardClient initialData={board} />
 }
 
 function ColumnSkeleton() {

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+import KanbanColumn, { KanbanItem } from './KanbanColumn'
+
+interface BoardState {
+  todo: KanbanItem[]
+  progress: KanbanItem[]
+  done: KanbanItem[]
+}
+
+interface BoardClientProps {
+  initialData: BoardState
+}
+
+export default function BoardClient({ initialData }: BoardClientProps) {
+  const [columns, setColumns] = useState<BoardState>(initialData)
+
+  const handleDrop = (column: keyof BoardState) => (id: string) => {
+    setColumns((prev) => {
+      let moved: KanbanItem | undefined
+      const next: BoardState = { ...prev }
+      for (const key of Object.keys(next) as Array<keyof BoardState>) {
+        const idx = next[key].findIndex((i) => i.id === id)
+        if (idx !== -1) {
+          moved = next[key].splice(idx, 1)[0]
+        }
+      }
+      if (moved) {
+        next[column].push(moved)
+      }
+      return { ...next }
+    })
+  }
+
+  return (
+    <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
+      <KanbanColumn title="Todo" items={columns.todo} onDrop={handleDrop('todo')} />
+      <KanbanColumn title="In Progress" items={columns.progress} onDrop={handleDrop('progress')} />
+      <KanbanColumn title="Done" items={columns.done} onDrop={handleDrop('done')} />
+    </main>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as KanbanCard } from './KanbanCard'
 export { default as KanbanColumn } from './KanbanColumn'
+export { default as BoardClient } from './BoardClient'
 export * from './ui'

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,10 @@
-import { Redis } from "@upstash/redis";
+import { Redis } from '@upstash/redis'
 
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+  url:
+    process.env.KV_REST_API_URL ||
+    process.env.UPSTASH_REDIS_REST_URL!,
+  token:
+    process.env.KV_REST_API_TOKEN ||
+    process.env.UPSTASH_REDIS_REST_TOKEN!,
+})

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,10 +1,7 @@
 import { Redis } from '@upstash/redis'
 
-export const redis = new Redis({
-  url:
-    process.env.KV_REST_API_URL ||
-    process.env.UPSTASH_REDIS_REST_URL!,
-  token:
-    process.env.KV_REST_API_TOKEN ||
-    process.env.UPSTASH_REDIS_REST_TOKEN!,
-})
+const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL
+const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN
+
+export const redis = url && token ? new Redis({ url, token }) : null
+


### PR DESCRIPTION
## Summary
- implement `app/board/page.tsx` to fetch board data from Redis using `unstable_cache`
- render board columns and cards
- add loading skeleton wrapped in `<Suspense>`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684de01c30488329a7f7aca58ffce813