### PR TITLE
Implement optimistic drag-and-drop updates

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,15 @@
+'use server'
+
+import { redis } from '@/lib/redis'
+import { columnCardsKey } from '@/lib/models'
+
+export async function moveCard(
+  cardId: string,
+  fromColumnId: string,
+  toColumnId: string
+) {
+  // remove card from its previous column
+  await redis.lrem(columnCardsKey(fromColumnId), 0, cardId)
+  // add card to the new column
+  await redis.rpush(columnCardsKey(toColumnId), cardId)
+}

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -6,11 +6,21 @@ import { cn } from '@/lib/utils'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string
+  columnId: string
 }
 
-export default function KanbanCard({ id, className, children, ...props }: KanbanCardProps) {
+export default function KanbanCard({
+  id,
+  columnId,
+  className,
+  children,
+  ...props
+}: KanbanCardProps) {
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
-    e.dataTransfer.setData('text/plain', id)
+    e.dataTransfer.setData(
+      'text/plain',
+      JSON.stringify({ cardId: id, fromColumnId: columnId })
+    )
   }
 
   return (

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -10,16 +10,26 @@ export interface KanbanItem {
 }
 
 interface KanbanColumnProps {
+  id: string
   title: string
   items: KanbanItem[]
-  onDrop: (id: string) => void
+  onDrop: (cardId: string, fromColumnId: string) => void
 }
 
-export default function KanbanColumn({ title, items, onDrop }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, items, onDrop }: KanbanColumnProps) {
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault()
-    const id = e.dataTransfer.getData('text/plain')
-    if (id) onDrop(id)
+    const data = e.dataTransfer.getData('text/plain')
+    if (!data) return
+    try {
+      const { cardId, fromColumnId } = JSON.parse(data) as {
+        cardId: string
+        fromColumnId: string
+      }
+      onDrop(cardId, fromColumnId)
+    } catch {
+      // ignore invalid data
+    }
   }
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault()
@@ -36,7 +46,7 @@ export default function KanbanColumn({ title, items, onDrop }: KanbanColumnProps
         onDragOver={handleDragOver}
       >
         {items.map((item) => (
-          <KanbanCard key={item.id} id={item.id}>
+          <KanbanCard key={item.id} id={item.id} columnId={id}>
             {item.content}
           </KanbanCard>
         ))}


### PR DESCRIPTION
## Summary
- update KanbanCard to include originating column information
- extend KanbanColumn to forward card drop metadata
- add server action to persist card moves in Redis
- optimistically update board state when dropping a card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684de357fb988329b2242cee93a4ed18