### PR TITLE
Apply modern design to kanban board

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -8,6 +8,9 @@ export async function moveCard(
   fromColumnId: string,
   toColumnId: string
 ) {
+  if (!redis) {
+    throw new Error('Redis client not configured')
+  }
   // remove card from its previous column
   await redis.lrem(columnCardsKey(fromColumnId), 0, cardId)
   // add card to the new column

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,26 +44,24 @@ export default function Home() {
       startTransition(() => moveCard(cardId, from, to))
     }
 
+  const lists = [
+    { id: 'todo', name: 'Todo', accent: 'border-orange-500', items: columns.todo },
+    { id: 'progress', name: 'In Progress', accent: 'border-blue-500', items: columns.progress },
+    { id: 'done', name: 'Done', accent: 'border-emerald-500', items: columns.done },
+  ]
+
   return (
-    <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-      <KanbanColumn
-        id="todo"
-        title="Todo"
-        items={columns.todo}
-        onDrop={handleDrop('todo')}
-      />
-      <KanbanColumn
-        id="progress"
-        title="In Progress"
-        items={columns.progress}
-        onDrop={handleDrop('progress')}
-      />
-      <KanbanColumn
-        id="done"
-        title="Done"
-        items={columns.done}
-        onDrop={handleDrop('done')}
-      />
+    <main className="min-h-screen bg-neutral-100 p-6 md:p-8 grid auto-cols-fr md:grid-cols-3 gap-6 font-sans">
+      {lists.map((list) => (
+        <KanbanColumn
+          key={list.id}
+          id={list.id}
+          title={list.name}
+          accent={list.accent}
+          items={list.items}
+          onDrop={handleDrop(list.id as keyof BoardState)}
+        />
+      ))}
     </main>
   )
 }

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React from 'react'
-import { Card } from './ui/card'
 import { cn } from '@/lib/utils'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -24,13 +23,16 @@ export default function KanbanCard({
   }
 
   return (
-    <Card
+    <div
       draggable
       onDragStart={handleDragStart}
-      className={cn('bg-background p-3 rounded-md shadow-sm cursor-grab active:cursor-grabbing', className)}
+      className={cn(
+        'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
+        className
+      )}
       {...props}
     >
       {children}
-    </Card>
+    </div>
   )
 }

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import KanbanCard from './KanbanCard'
-import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
 
 export interface KanbanItem {
   id: string
@@ -12,11 +11,12 @@ export interface KanbanItem {
 interface KanbanColumnProps {
   id: string
   title: string
+  accent: string
   items: KanbanItem[]
   onDrop: (cardId: string, fromColumnId: string) => void
 }
 
-export default function KanbanColumn({ id, title, items, onDrop }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onDrop }: KanbanColumnProps) {
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault()
     const data = e.dataTransfer.getData('text/plain')
@@ -36,12 +36,10 @@ export default function KanbanColumn({ id, title, items, onDrop }: KanbanColumnP
   }
 
   return (
-    <Card className="bg-muted/50">
-      <CardHeader className="p-4 border-b">
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
-      </CardHeader>
-      <CardContent
-        className="flex flex-col gap-2 p-4 min-h-24"
+    <section className="flex flex-col bg-white/60 backdrop-blur-md border border-neutral-300 rounded-2xl shadow-sm hover:shadow-md transition-shadow">
+      <header className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase border-l-4 ${accent}`}>{title}</header>
+      <div
+        className="flex flex-col gap-3 p-4 grow"
         onDrop={handleDrop}
         onDragOver={handleDragOver}
       >
@@ -50,7 +48,7 @@ export default function KanbanColumn({ id, title, items, onDrop }: KanbanColumnP
             {item.content}
           </KanbanCard>
         ))}
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- restyle board with soft glass columns and playful accent colours
- update column and card components with new classes
- simplify board layout to use new styles
- throw if redis client misconfigured

## Testing
- `npx next lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dea1189d483298cc4baae976da153