### PR TITLE
Enable dnd-kit drag and drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kanban-app",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@upstash/redis": "^1.35.0",
         "class-variance-authority": "^0.7.1",
@@ -55,6 +56,45 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@upstash/redis": "^1.35.0",
     "class-variance-authority": "^0.7.1",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import { DndContext, type DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from '@/components/KanbanColumn'
 import { moveCard } from './actions'
 
@@ -23,26 +24,33 @@ export default function Home() {
   const [columns, setColumns] = useState<BoardState>(initialState)
   const [, startTransition] = useTransition()
 
-  const handleDrop =
-    (to: keyof BoardState) =>
-    (cardId: string, from: string) => {
-      setColumns((prev) => {
-        let moved: KanbanItem | undefined
-        const next: BoardState = { ...prev }
-        for (const key of Object.keys(next) as Array<keyof BoardState>) {
-          const idx = next[key].findIndex((i) => i.id === cardId)
-          if (idx !== -1) {
-            moved = next[key].splice(idx, 1)[0]
-          }
-        }
-        if (moved) {
-          next[to].push(moved)
-        }
-        return { ...next }
-      })
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over) return
 
-      startTransition(() => moveCard(cardId, from, to))
-    }
+    const cardId = String(active.id)
+    const from = active.data.current?.columnId as keyof BoardState | undefined
+    const to = over.id as keyof BoardState
+
+    if (!from) return
+
+    setColumns((prev) => {
+      let moved: KanbanItem | undefined
+      const next: BoardState = { ...prev }
+      for (const key of Object.keys(next) as Array<keyof BoardState>) {
+        const idx = next[key].findIndex((i) => i.id === cardId)
+        if (idx !== -1) {
+          moved = next[key].splice(idx, 1)[0]
+        }
+      }
+      if (moved) {
+        next[to].push(moved)
+      }
+      return { ...next }
+    })
+
+    startTransition(() => moveCard(cardId, from, to))
+  }
 
   const lists = [
     { id: 'todo', name: 'Todo', accent: 'border-orange-500', items: columns.todo },
@@ -51,17 +59,18 @@ export default function Home() {
   ]
 
   return (
-    <main className="min-h-screen bg-neutral-100 p-6 md:p-8 grid auto-cols-fr md:grid-cols-3 gap-6 font-sans">
-      {lists.map((list) => (
-        <KanbanColumn
-          key={list.id}
-          id={list.id}
-          title={list.name}
-          accent={list.accent}
-          items={list.items}
-          onDrop={handleDrop(list.id as keyof BoardState)}
-        />
-      ))}
-    </main>
+    <DndContext onDragEnd={handleDragEnd}>
+      <main className="min-h-screen bg-neutral-100 p-6 md:p-8 grid auto-cols-fr md:grid-cols-3 gap-6 font-sans">
+        {lists.map((list) => (
+          <KanbanColumn
+            key={list.id}
+            id={list.id}
+            title={list.name}
+            accent={list.accent}
+            items={list.items}
+          />
+        ))}
+      </main>
+    </DndContext>
   )
 }

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -15,21 +16,21 @@ export default function KanbanCard({
   children,
   ...props
 }: KanbanCardProps) {
-  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
-    e.dataTransfer.setData(
-      'text/plain',
-      JSON.stringify({ cardId: id, fromColumnId: columnId })
-    )
-  }
+  const { setNodeRef, attributes, listeners, isDragging } = useDraggable({
+    id,
+    data: { columnId },
+  })
 
   return (
     <div
-      draggable
-      onDragStart={handleDragStart}
+      ref={setNodeRef}
       className={cn(
         'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
+        isDragging && 'ring-2 ring-secondary',
         className
       )}
+      {...listeners}
+      {...attributes}
       {...props}
     >
       {children}

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useDroppable } from '@dnd-kit/core'
 import KanbanCard from './KanbanCard'
 
 export interface KanbanItem {
@@ -13,36 +14,15 @@ interface KanbanColumnProps {
   title: string
   accent: string
   items: KanbanItem[]
-  onDrop: (cardId: string, fromColumnId: string) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items, onDrop }: KanbanColumnProps) {
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    const data = e.dataTransfer.getData('text/plain')
-    if (!data) return
-    try {
-      const { cardId, fromColumnId } = JSON.parse(data) as {
-        cardId: string
-        fromColumnId: string
-      }
-      onDrop(cardId, fromColumnId)
-    } catch {
-      // ignore invalid data
-    }
-  }
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-  }
+export default function KanbanColumn({ id, title, accent, items }: KanbanColumnProps) {
+  const { setNodeRef } = useDroppable({ id })
 
   return (
     <section className="flex flex-col bg-white/60 backdrop-blur-md border border-neutral-300 rounded-2xl shadow-sm hover:shadow-md transition-shadow">
       <header className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase border-l-4 ${accent}`}>{title}</header>
-      <div
-        className="flex flex-col gap-3 p-4 grow"
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-      >
+      <div ref={setNodeRef} className="flex flex-col gap-3 p-4 grow">
         {items.map((item) => (
           <KanbanCard key={item.id} id={item.id} columnId={id}>
             {item.content}


### PR DESCRIPTION
## Summary
- add `@dnd-kit/core` dependency
- wrap board pages with `DndContext`
- convert cards and columns to use `useDraggable`/`useDroppable`
- update state handling for drag & drop

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dedc3d5a88329b02a4282d170c089