### PR TITLE
Add input field to create new cards in Todo column

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,18 @@ export default function Home() {
   const [columns, setColumns] = useState<BoardState>(initialState)
   const [, startTransition] = useTransition()
 
+  const handleAddCard = (content: string) => {
+    const newCard: KanbanItem = {
+      id: `card-${Date.now()}`,
+      content: content
+    }
+    
+    setColumns(prev => ({
+      ...prev,
+      todo: [...prev.todo, newCard]
+    }))
+  }
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
     
@@ -74,6 +86,7 @@ export default function Home() {
             title={list.name}
             accent={list.accent}
             items={list.items}
+            onAddCard={list.id === 'todo' ? handleAddCard : undefined}
           />
         ))}
       </main>

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -17,6 +17,18 @@ interface BoardClientProps {
 export default function BoardClient({ initialData }: BoardClientProps) {
   const [columns, setColumns] = useState<BoardState>(initialData)
 
+  const handleAddCard = (content: string) => {
+    const newCard: KanbanItem = {
+      id: `card-${Date.now()}`,
+      content: content
+    }
+    
+    setColumns(prev => ({
+      ...prev,
+      todo: [...prev.todo, newCard]
+    }))
+  }
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
     
@@ -56,7 +68,8 @@ export default function BoardClient({ initialData }: BoardClientProps) {
           id="todo"
           title="Todo" 
           accent="border-orange-500" 
-          items={columns.todo} 
+          items={columns.todo}
+          onAddCard={handleAddCard}
         />
         <KanbanColumn 
           id="progress"

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { useState, KeyboardEvent } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import KanbanCard from './KanbanCard'
 
@@ -14,12 +14,33 @@ interface KanbanColumnProps {
   title: string
   accent: string
   items: KanbanItem[]
+  onAddCard?: (content: string) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onAddCard }: KanbanColumnProps) {
+  const [inputValue, setInputValue] = useState('')
   const { setNodeRef } = useDroppable({
     id: id,
   })
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      if (inputValue.trim() && onAddCard) {
+        onAddCard(inputValue.trim())
+        setInputValue('')
+        // Reset textarea height
+        e.currentTarget.style.height = 'auto'
+      }
+    }
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputValue(e.target.value)
+    // Auto-resize textarea
+    e.target.style.height = 'auto'
+    e.target.style.height = `${e.target.scrollHeight}px`
+  }
 
   return (
     <section className="flex flex-col bg-white/60 backdrop-blur-md border border-neutral-300 rounded-2xl shadow-sm hover:shadow-md transition-shadow">
@@ -28,6 +49,16 @@ export default function KanbanColumn({ id, title, accent, items }: KanbanColumnP
         ref={setNodeRef}
         className="flex flex-col gap-3 p-4 grow"
       >
+        {onAddCard && (
+          <textarea
+            value={inputValue}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            placeholder="Type and press Enter to add a card..."
+            className="w-full px-3 py-2 text-sm bg-white border border-neutral-300 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder:text-neutral-400 min-h-[36px]"
+            rows={1}
+          />
+        )}
         {items.map((item) => (
           <KanbanCard key={item.id} id={item.id} columnId={id}>
             {item.content}


### PR DESCRIPTION
## Summary
Added an input field at the top of the Todo column that allows users to create new cards by typing and pressing Enter.

## Features
- **Input textarea** at the top of Todo column
- **Enter key** creates a new card with the typed content
- **Shift+Enter** allows multiline input
- **Auto-resize** textarea grows/shrinks based on content
- **Clear on submit** - input is cleared after creating a card
- Works on both main page (/) and board page (/board)

## Technical Details
- Added optional `onAddCard` prop to KanbanColumn component
- Textarea only appears when `onAddCard` prop is provided
- New cards get unique IDs using timestamp: `card-${Date.now()}`
- Auto-resize implemented by adjusting textarea height based on scrollHeight
- Proper keyboard event handling to differentiate Enter vs Shift+Enter

## Testing
- [x] `npm run lint` - no errors
- [x] `npm run build` - builds successfully
- [x] Manual testing:
  - Type text and press Enter to create card
  - Use Shift+Enter to add newlines
  - Textarea auto-resizes with content
  - Input clears after card creation

🤖 Generated with [Claude Code](https://claude.ai/code)