### PR TITLE
Fix database persistence for card movements

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,14 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
 import { redis } from '@/lib/redis'
-import { columnCardsKey } from '@/lib/models'
+import { KanbanItem } from '@/components/KanbanColumn'
+
+interface BoardState {
+  todo: KanbanItem[]
+  progress: KanbanItem[]
+  done: KanbanItem[]
+}
 
 export async function moveCard(
   cardId: string,
@@ -9,10 +16,106 @@ export async function moveCard(
   toColumnId: string
 ) {
   if (!redis) {
-    throw new Error('Redis client not configured')
+    console.warn('Redis client not configured - changes will not persist')
+    return
   }
-  // remove card from its previous column
-  await redis.lrem(columnCardsKey(fromColumnId), 0, cardId)
-  // add card to the new column
-  await redis.rpush(columnCardsKey(toColumnId), cardId)
+
+  try {
+    // Get current board state
+    const board = await redis.get<BoardState>('board') || {
+      todo: [],
+      progress: [],
+      done: []
+    }
+
+    // Find and move the card
+    const fromColumn = board[fromColumnId as keyof BoardState]
+    const cardIndex = fromColumn.findIndex(item => item.id === cardId)
+    
+    if (cardIndex !== -1) {
+      const [movedCard] = fromColumn.splice(cardIndex, 1)
+      const toColumn = board[toColumnId as keyof BoardState]
+      toColumn.push(movedCard)
+      
+      // Save updated board state
+      await redis.set('board', board)
+    }
+
+    // Revalidate the board page cache
+    revalidatePath('/board')
+  } catch (error) {
+    console.error('Failed to move card:', error)
+  }
+}
+
+export async function addCard(content: string, columnId: string) {
+  if (!redis) {
+    console.warn('Redis client not configured - changes will not persist')
+    return
+  }
+
+  try {
+    // Get current board state
+    const board = await redis.get<BoardState>('board') || {
+      todo: [],
+      progress: [],
+      done: []
+    }
+
+    // Create new card
+    const newCard: KanbanItem = {
+      id: `card-${Date.now()}`,
+      content: content
+    }
+
+    // Add to the specified column
+    const column = board[columnId as keyof BoardState]
+    column.push(newCard)
+
+    // Save updated board state
+    await redis.set('board', board)
+
+    // Revalidate the board page cache
+    revalidatePath('/board')
+  } catch (error) {
+    console.error('Failed to add card:', error)
+  }
+}
+
+export async function getBoard(): Promise<BoardState> {
+  if (!redis) {
+    console.warn('Redis client not configured - returning default board')
+    return {
+      todo: [],
+      progress: [],
+      done: []
+    }
+  }
+
+  try {
+    const board = await redis.get<BoardState>('board')
+    
+    // If no board exists, create one with initial data
+    if (!board) {
+      const initialBoard: BoardState = {
+        todo: [
+          { id: '1', content: 'Add drag & drop' },
+          { id: '2', content: 'Style components' },
+        ],
+        progress: [{ id: '3', content: 'Write docs' }],
+        done: [{ id: '4', content: 'Setup project' }],
+      }
+      await redis.set('board', initialBoard)
+      return initialBoard
+    }
+    
+    return board
+  } catch (error) {
+    console.error('Failed to get board:', error)
+    return {
+      todo: [],
+      progress: [],
+      done: []
+    }
+  }
 }

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,27 +1,7 @@
 import { Suspense } from 'react'
-import { unstable_cache } from 'next/cache'
-
 import { BoardClient } from '@/components'
-import type { KanbanItem } from '@/components/KanbanColumn'
-import { redis } from '@/lib/redis'
+import { getBoard } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-
-interface BoardState {
-  todo: KanbanItem[]
-  progress: KanbanItem[]
-  done: KanbanItem[]
-}
-
-const getBoard = unstable_cache(async () => {
-  if (!redis) return { todo: [], progress: [], done: [] }
-  try {
-    const data = await redis.get<BoardState>('board')
-    if (data) return data
-  } catch {
-    return { todo: [], progress: [], done: [] }
-  }
-  return { todo: [], progress: [], done: [] }
-}, ['board'])
 
 async function Board() {
   const board = await getBoard()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from '@/components/KanbanColumn'
-import { moveCard } from './actions'
+import { moveCard, addCard } from './actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -34,6 +34,9 @@ export default function Home() {
       ...prev,
       todo: [...prev.todo, newCard]
     }))
+
+    // Persist to database if Redis is configured
+    startTransition(() => addCard(content, 'todo'))
   }
 
   const handleDragEnd = (event: DragEndEvent) => {

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
+import { moveCard, addCard } from '@/app/actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -16,6 +17,7 @@ interface BoardClientProps {
 
 export default function BoardClient({ initialData }: BoardClientProps) {
   const [columns, setColumns] = useState<BoardState>(initialData)
+  const [, startTransition] = useTransition()
 
   const handleAddCard = (content: string) => {
     const newCard: KanbanItem = {
@@ -27,6 +29,9 @@ export default function BoardClient({ initialData }: BoardClientProps) {
       ...prev,
       todo: [...prev.todo, newCard]
     }))
+
+    // Persist to database
+    startTransition(() => addCard(content, 'todo'))
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -59,6 +64,9 @@ export default function BoardClient({ initialData }: BoardClientProps) {
       
       return { ...next }
     })
+
+    // Persist to database
+    startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 
   return (


### PR DESCRIPTION
## Summary
Fixed the issue where moved cards don't persist after page refresh. The problem was a mismatch between how data was being read and written to Redis.

## Root Cause
1. **Data structure mismatch**: Board page read from a single `'board'` key, but `moveCard` wrote to granular keys like `columns:${id}:cards`
2. **Missing integration**: Client components updated local state but didn't call server actions
3. **No cache revalidation**: Changes weren't reflected due to aggressive caching

## Changes Made
1. **Unified Redis structure**: All operations now use a single `'board'` key storing the complete board state
2. **Server action integration**: 
   - `BoardClient` now calls `moveCard` and `addCard` server actions
   - Main page also persists changes when Redis is configured
3. **Cache revalidation**: Added `revalidatePath('/board')` after mutations
4. **Board initialization**: Created `getBoard()` function that initializes default data if none exists
5. **Error handling**: Graceful fallbacks when Redis is not configured

## Technical Details
- Removed dependency on unused granular key structure from `lib/models/keys.ts`
- Board data structure: `{ todo: KanbanItem[], progress: KanbanItem[], done: KanbanItem[] }`
- All CRUD operations now consistently use this structure
- Board page is now dynamic (server-rendered) to reflect latest data

## Testing
- [x] `npm run lint` - no errors
- [x] `npm run build` - builds successfully
- [x] Manual testing:
  - Move cards between columns
  - Add new cards
  - Refresh page - changes persist (when Redis is configured)
  - Works without Redis (graceful degradation with console warnings)

🤖 Generated with [Claude Code](https://claude.ai/code)