### PR TITLE
Add delete option for kanban cards

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -137,6 +137,45 @@ export async function addCard(content: string, columnId: string) {
   }
 }
 
+export async function deleteCard(cardId: string, columnId: string) {
+  if (!redis) {
+    console.warn('Redis client not configured - changes will not persist')
+    return
+  }
+
+  console.log(`Deleting card ${cardId} from ${columnId}`)
+
+  try {
+    const board = (await redis.get<BoardState>('board')) || {
+      todo: [],
+      progress: [],
+      done: [],
+    }
+
+    const column = board[columnId as keyof BoardState]
+
+    if (!column) {
+      console.error(`Invalid column ID: ${columnId}`)
+      return
+    }
+
+    const idx = column.findIndex((c) => c.id === cardId)
+    if (idx !== -1) {
+      column.splice(idx, 1)
+      await redis.set('board', board)
+      await cleanupOldKeys()
+    } else {
+      console.warn(`Card ${cardId} not found in column ${columnId}`)
+    }
+
+    revalidatePath('/board')
+    revalidatePath('/')
+  } catch (error) {
+    console.error('Failed to delete card:', error)
+    throw error
+  }
+}
+
 // Debug function to reset the board
 export async function resetBoard() {
   if (!redis) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from '@/components/KanbanColumn'
-import { moveCard, addCard } from './actions'
+import { moveCard, addCard, deleteCard } from './actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -73,6 +73,17 @@ export default function Home() {
     startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 
+  const handleDeleteCard = (columnId: string, cardId: string) => {
+    setColumns((prev) => {
+      const next = { ...prev }
+      const col = columnId as keyof BoardState
+      next[col] = prev[col].filter((c) => c.id !== cardId)
+      return next
+    })
+
+    startTransition(() => deleteCard(cardId, columnId))
+  }
+
   const lists = [
     { id: 'todo', name: 'Todo', accent: 'border-orange-500', items: columns.todo },
     { id: 'progress', name: 'In Progress', accent: 'border-blue-500', items: columns.progress },
@@ -90,6 +101,7 @@ export default function Home() {
             accent={list.accent}
             items={list.items}
             onAddCard={list.id === 'todo' ? handleAddCard : undefined}
+            onDeleteCard={handleDeleteCard}
           />
         ))}
       </main>

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
-import { moveCard, addCard } from '@/app/actions'
+import { moveCard, addCard, deleteCard } from '@/app/actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -69,27 +69,41 @@ export default function BoardClient({ initialData }: BoardClientProps) {
     startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 
+  const handleDeleteCard = (columnId: string, cardId: string) => {
+    setColumns((prev) => {
+      const next = { ...prev }
+      const col = columnId as keyof BoardState
+      next[col] = prev[col].filter((c) => c.id !== cardId)
+      return next
+    })
+
+    startTransition(() => deleteCard(cardId, columnId))
+  }
+
   return (
     <DndContext onDragEnd={handleDragEnd}>
       <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-        <KanbanColumn 
+        <KanbanColumn
           id="todo"
-          title="Todo" 
-          accent="border-orange-500" 
+          title="Todo"
+          accent="border-orange-500"
           items={columns.todo}
           onAddCard={handleAddCard}
+          onDeleteCard={handleDeleteCard}
         />
-        <KanbanColumn 
+        <KanbanColumn
           id="progress"
-          title="In Progress" 
-          accent="border-blue-500" 
-          items={columns.progress} 
+          title="In Progress"
+          accent="border-blue-500"
+          items={columns.progress}
+          onDeleteCard={handleDeleteCard}
         />
-        <KanbanColumn 
+        <KanbanColumn
           id="done"
-          title="Done" 
-          accent="border-green-500" 
-          items={columns.done} 
+          title="Done"
+          accent="border-green-500"
+          items={columns.done}
+          onDeleteCard={handleDeleteCard}
         />
       </main>
     </DndContext>

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
+import { MoreHorizontal } from 'lucide-react'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string
   columnId: string
+  onDelete?: () => void
 }
 
 export default function KanbanCard({
@@ -14,6 +16,7 @@ export default function KanbanCard({
   columnId,
   className,
   children,
+  onDelete,
   ...props
 }: KanbanCardProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -23,19 +26,44 @@ export default function KanbanCard({
     },
   })
 
+  const [menuOpen, setMenuOpen] = useState(false)
+
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       className={cn(
-        'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
+        'relative bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
         isDragging ? 'ring-2 ring-blue-500' : '',
         className
       )}
       {...props}
     >
       {children}
+      <button
+        className="absolute top-1 right-1 p-1 text-neutral-500 hover:text-neutral-700"
+        onClick={(e) => {
+          e.stopPropagation()
+          setMenuOpen((p) => !p)
+        }}
+      >
+        <MoreHorizontal className="w-4 h-4" />
+      </button>
+      {menuOpen && (
+        <div className="absolute z-10 top-7 right-1 bg-white border border-neutral-300 rounded-md shadow-md">
+          <button
+            className="px-3 py-1 text-sm text-left text-red-600 hover:bg-red-50 w-full"
+            onClick={(e) => {
+              e.stopPropagation()
+              setMenuOpen(false)
+              onDelete?.()
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -15,9 +15,10 @@ interface KanbanColumnProps {
   accent: string
   items: KanbanItem[]
   onAddCard?: (content: string) => void
+  onDeleteCard?: (columnId: string, cardId: string) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items, onAddCard }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onAddCard, onDeleteCard }: KanbanColumnProps) {
   const [inputValue, setInputValue] = useState('')
   const { setNodeRef } = useDroppable({
     id: id,
@@ -60,7 +61,12 @@ export default function KanbanColumn({ id, title, accent, items, onAddCard }: Ka
           />
         )}
         {items.map((item) => (
-          <KanbanCard key={item.id} id={item.id} columnId={id}>
+          <KanbanCard
+            key={item.id}
+            id={item.id}
+            columnId={id}
+            onDelete={() => onDeleteCard?.(id, item.id)}
+          >
             {item.content}
           </KanbanCard>
         ))}


### PR DESCRIPTION
## Summary
- implement `deleteCard` server action
- provide delete controls on `KanbanCard`
- propagate delete callbacks through `KanbanColumn`, `BoardClient` and home page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e011c71248329bb661b819437055a