### PR TITLE
Add delete option via card menu

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -137,6 +137,45 @@ export async function addCard(content: string, columnId: string) {
   }
 }
 
+export async function deleteCard(cardId: string, columnId: string) {
+  if (!redis) {
+    console.warn('Redis client not configured - changes will not persist')
+    return
+  }
+
+  console.log(`Deleting card ${cardId} from ${columnId}`)
+
+  try {
+    const board = await redis.get<BoardState>('board')
+
+    if (!board) {
+      console.warn('No board found in Redis')
+      return
+    }
+
+    const column = board[columnId as keyof BoardState]
+    if (!column) {
+      console.error(`Invalid column ID: ${columnId}`)
+      return
+    }
+
+    const idx = column.findIndex((c) => c.id === cardId)
+    if (idx !== -1) {
+      column.splice(idx, 1)
+      await redis.set('board', board)
+      await cleanupOldKeys()
+    } else {
+      console.warn(`Card ${cardId} not found in column ${columnId}`)
+    }
+
+    revalidatePath('/board')
+    revalidatePath('/')
+  } catch (error) {
+    console.error('Failed to delete card:', error)
+    throw error
+  }
+}
+
 // Debug function to reset the board
 export async function resetBoard() {
   if (!redis) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from '@/components/KanbanColumn'
-import { moveCard, addCard } from './actions'
+import { moveCard, addCard, deleteCard } from './actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -73,6 +73,17 @@ export default function Home() {
     startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 
+  const handleDeleteCard = (cardId: string, columnId: string) => {
+    setColumns(prev => {
+      const next: BoardState = { ...prev }
+      const column = columnId as keyof BoardState
+      next[column] = next[column].filter(c => c.id !== cardId)
+      return { ...next }
+    })
+
+    startTransition(() => deleteCard(cardId, columnId))
+  }
+
   const lists = [
     { id: 'todo', name: 'Todo', accent: 'border-orange-500', items: columns.todo },
     { id: 'progress', name: 'In Progress', accent: 'border-blue-500', items: columns.progress },
@@ -90,6 +101,7 @@ export default function Home() {
             accent={list.accent}
             items={list.items}
             onAddCard={list.id === 'todo' ? handleAddCard : undefined}
+            onDeleteCard={handleDeleteCard}
           />
         ))}
       </main>

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
-import { moveCard, addCard } from '@/app/actions'
+import { moveCard, addCard, deleteCard } from '@/app/actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -69,27 +69,41 @@ export default function BoardClient({ initialData }: BoardClientProps) {
     startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 
+  const handleDeleteCard = (cardId: string, columnId: string) => {
+    setColumns(prev => {
+      const next: BoardState = { ...prev }
+      const column = columnId as keyof BoardState
+      next[column] = next[column].filter(c => c.id !== cardId)
+      return { ...next }
+    })
+
+    startTransition(() => deleteCard(cardId, columnId))
+  }
+
   return (
     <DndContext onDragEnd={handleDragEnd}>
       <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-        <KanbanColumn 
+        <KanbanColumn
           id="todo"
-          title="Todo" 
-          accent="border-orange-500" 
+          title="Todo"
+          accent="border-orange-500"
           items={columns.todo}
           onAddCard={handleAddCard}
+          onDeleteCard={handleDeleteCard}
         />
-        <KanbanColumn 
+        <KanbanColumn
           id="progress"
-          title="In Progress" 
-          accent="border-blue-500" 
-          items={columns.progress} 
+          title="In Progress"
+          accent="border-blue-500"
+          items={columns.progress}
+          onDeleteCard={handleDeleteCard}
         />
-        <KanbanColumn 
+        <KanbanColumn
           id="done"
-          title="Done" 
-          accent="border-green-500" 
-          items={columns.done} 
+          title="Done"
+          accent="border-green-500"
+          items={columns.done}
+          onDeleteCard={handleDeleteCard}
         />
       </main>
     </DndContext>

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import React from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
+import { MoreVertical } from 'lucide-react'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string
   columnId: string
+  onDelete?: (cardId: string, columnId: string) => void
 }
 
 export default function KanbanCard({
@@ -14,6 +16,7 @@ export default function KanbanCard({
   columnId,
   className,
   children,
+  onDelete,
   ...props
 }: KanbanCardProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -23,18 +26,60 @@ export default function KanbanCard({
     },
   })
 
+  const [open, setOpen] = useState(false)
+  const btnRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (btnRef.current && !btnRef.current.parentElement?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('click', handleClickOutside)
+    }
+    return () => document.removeEventListener('click', handleClickOutside)
+  }, [open])
+
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       className={cn(
-        'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
+        'relative bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
         isDragging ? 'ring-2 ring-blue-500' : '',
         className
       )}
       {...props}
     >
+      <button
+        ref={btnRef}
+        type="button"
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((p) => !p)
+        }}
+        className="absolute top-1 right-1 p-1 rounded hover:bg-neutral-100"
+      >
+        <MoreVertical className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute top-7 right-1 z-10 bg-white border border-neutral-200 rounded-md shadow-md">
+          <button
+            className="block w-full text-left px-3 py-1 text-sm hover:bg-neutral-100"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete?.(id, columnId)
+              setOpen(false)
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
       {children}
     </div>
   )

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -15,9 +15,10 @@ interface KanbanColumnProps {
   accent: string
   items: KanbanItem[]
   onAddCard?: (content: string) => void
+  onDeleteCard?: (cardId: string, columnId: string) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items, onAddCard }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onAddCard, onDeleteCard }: KanbanColumnProps) {
   const [inputValue, setInputValue] = useState('')
   const { setNodeRef } = useDroppable({
     id: id,
@@ -60,7 +61,12 @@ export default function KanbanColumn({ id, title, accent, items, onAddCard }: Ka
           />
         )}
         {items.map((item) => (
-          <KanbanCard key={item.id} id={item.id} columnId={id}>
+          <KanbanCard
+            key={item.id}
+            id={item.id}
+            columnId={id}
+            onDelete={onDeleteCard}
+          >
             {item.content}
           </KanbanCard>
         ))}


### PR DESCRIPTION
## Summary
- implement card deletion server action
- update board client and page to handle deleting cards
- extend kanban column and card components to support a context menu
- add UI for deleting cards from a new `...` menu on each card

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e011c71248329bb661b819437055a