### PR TITLE
Add card deletion menu

### DIFF
--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
-import { moveCard, addCard } from '@/app/actions'
+import { moveCard, addCard, deleteCard } from '@/app/actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -18,6 +18,16 @@ interface BoardClientProps {
 export default function BoardClient({ initialData }: BoardClientProps) {
   const [columns, setColumns] = useState<BoardState>(initialData)
   const [, startTransition] = useTransition()
+
+  const handleDeleteCard = (cardId: string) => {
+    setColumns(prev => ({
+      todo: prev.todo.filter(c => c.id !== cardId),
+      progress: prev.progress.filter(c => c.id !== cardId),
+      done: prev.done.filter(c => c.id !== cardId),
+    }))
+
+    startTransition(() => deleteCard(cardId))
+  }
 
   const handleAddCard = (content: string) => {
     const newCard: KanbanItem = {
@@ -72,24 +82,27 @@ export default function BoardClient({ initialData }: BoardClientProps) {
   return (
     <DndContext onDragEnd={handleDragEnd}>
       <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-        <KanbanColumn 
+        <KanbanColumn
           id="todo"
-          title="Todo" 
-          accent="border-orange-500" 
+          title="Todo"
+          accent="border-orange-500"
           items={columns.todo}
           onAddCard={handleAddCard}
+          onDeleteCard={handleDeleteCard}
         />
-        <KanbanColumn 
+        <KanbanColumn
           id="progress"
-          title="In Progress" 
-          accent="border-blue-500" 
-          items={columns.progress} 
+          title="In Progress"
+          accent="border-blue-500"
+          items={columns.progress}
+          onDeleteCard={handleDeleteCard}
         />
-        <KanbanColumn 
+        <KanbanColumn
           id="done"
-          title="Done" 
-          accent="border-green-500" 
-          items={columns.done} 
+          title="Done"
+          accent="border-green-500"
+          items={columns.done}
+          onDeleteCard={handleDeleteCard}
         />
       </main>
     </DndContext>

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
+import { MoreVertical } from 'lucide-react'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string
   columnId: string
+  onDelete?: (cardId: string) => void
 }
 
 export default function KanbanCard({
@@ -14,6 +16,7 @@ export default function KanbanCard({
   columnId,
   className,
   children,
+  onDelete,
   ...props
 }: KanbanCardProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -23,18 +26,47 @@ export default function KanbanCard({
     },
   })
 
+  const [open, setOpen] = useState(false)
+
+  const toggleMenu = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setOpen((prev) => !prev)
+  }
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setOpen(false)
+    onDelete?.(id)
+  }
+
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       className={cn(
-        'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
+        'relative bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
         isDragging ? 'ring-2 ring-blue-500' : '',
         className
       )}
       {...props}
     >
+      <button
+        onClick={toggleMenu}
+        className="absolute top-1 right-1 p-1 rounded text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100"
+      >
+        <MoreVertical className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute right-1 top-7 z-10 bg-white border border-neutral-300 rounded-md shadow-md">
+          <button
+            onClick={handleDelete}
+            className="block px-3 py-1 text-sm hover:bg-neutral-100 w-full text-left"
+          >
+            Delete
+          </button>
+        </div>
+      )}
       {children}
     </div>
   )

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -15,9 +15,10 @@ interface KanbanColumnProps {
   accent: string
   items: KanbanItem[]
   onAddCard?: (content: string) => void
+  onDeleteCard?: (cardId: string) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items, onAddCard }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onAddCard, onDeleteCard }: KanbanColumnProps) {
   const [inputValue, setInputValue] = useState('')
   const { setNodeRef } = useDroppable({
     id: id,
@@ -60,7 +61,12 @@ export default function KanbanColumn({ id, title, accent, items, onAddCard }: Ka
           />
         )}
         {items.map((item) => (
-          <KanbanCard key={item.id} id={item.id} columnId={id}>
+          <KanbanCard
+            key={item.id}
+            id={item.id}
+            columnId={id}
+            onDelete={onDeleteCard}
+          >
             {item.content}
           </KanbanCard>
         ))}


### PR DESCRIPTION
## Summary
- add deleteCard action on server
- update Kanban card component with context menu
- handle card deletion in the board client
- allow columns to forward delete handler to cards

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e011c71248329bb661b819437055a