### PR TITLE
Fix board not persisting across refresh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useState, useTransition, useEffect } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from '@/components/KanbanColumn'
 import { moveCard, addCard } from './actions'
@@ -20,9 +20,27 @@ const initialState: BoardState = {
   done: [{ id: '4', content: 'Setup project' }],
 }
 
+const STORAGE_KEY = 'board-state'
+
 export default function Home() {
   const [columns, setColumns] = useState<BoardState>(initialState)
   const [, startTransition] = useTransition()
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as BoardState
+        setColumns(parsed)
+      } catch {
+        // ignore parse errors and use default state
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(columns))
+  }, [columns])
 
   const handleAddCard = (content: string) => {
     const newCard: KanbanItem = {

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useState, useTransition, useEffect } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
 import { moveCard, addCard } from '@/app/actions'
@@ -15,9 +15,27 @@ interface BoardClientProps {
   initialData: BoardState
 }
 
+const STORAGE_KEY = 'board-state'
+
 export default function BoardClient({ initialData }: BoardClientProps) {
   const [columns, setColumns] = useState<BoardState>(initialData)
   const [, startTransition] = useTransition()
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as BoardState
+        setColumns(parsed)
+      } catch {
+        // ignore parse errors and use initial data
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(columns))
+  }, [columns])
 
   const handleAddCard = (content: string) => {
     const newCard: KanbanItem = {


### PR DESCRIPTION
## Summary
- persist board state in local storage
- read initial state from local storage on load

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e00fd0b748329ae2241d7104426f8