### PR TITLE
Add card modal with editable description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Kanban board application built with Next.js 15, TypeScript, and Redis (via Upstash). The app uses React 19 with the Next.js App Router and implements drag-and-drop functionality for task management.
+
+## Commands
+
+```bash
+# Development
+npm run dev         # Start development server with Turbopack
+
+# Build & Production
+npm run build       # Build for production
+npm run start       # Start production server
+
+# Code Quality
+npm run lint        # Run ESLint
+```
+
+## Architecture
+
+### Data Flow
+1. **Client State**: Uses React `useState` for local board state management
+2. **Server Actions**: Next.js server actions handle Redis operations (e.g., `moveCard` in `app/actions.ts`)
+3. **Optimistic Updates**: Uses `useTransition` for immediate UI feedback before server confirmation
+4. **Persistence**: Redis stores board data with structured keys
+
+### Redis Key Structure
+```
+boards:${boardId}           # Board metadata
+boards:${boardId}:columns   # List of column IDs
+columns:${columnId}         # Column metadata
+columns:${columnId}:cards   # List of card IDs
+cards:${cardId}            # Individual card data
+```
+
+### Component Hierarchy
+- **Server Components**: Handle data fetching (pages)
+- **Client Components**: Handle interactivity (`BoardClient`, `KanbanColumn`, `KanbanCard`)
+- **UI Primitives**: Reusable components in `src/components/ui/`
+
+### Key Patterns
+- **Drag & Drop**: Native HTML5 drag-and-drop API
+- **Type Safety**: Comprehensive TypeScript interfaces (`KanbanItem`, `BoardState`)
+- **Styling**: Tailwind CSS v4 with glass-morphism design
+- **Error Handling**: Redis client checks for availability before operations
+
+## Environment Setup
+
+Requires environment variables for Redis connection:
+- `UPSTASH_REDIS_REST_URL`
+- `UPSTASH_REDIS_REST_TOKEN`
+
+## Tech Stack
+- **Framework**: Next.js 15.3.3 with App Router
+- **Language**: TypeScript 5
+- **UI**: React 19, Radix UI, Lucide Icons
+- **Styling**: Tailwind CSS v4
+- **Database**: Redis (Upstash)
+- **Build**: Turbopack (dev), Webpack (production)

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -3,7 +3,8 @@
 import { useState, useTransition } from 'react'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
-import { moveCard, addCard } from '@/app/actions'
+import CardDetailModal from './CardDetailModal'
+import { moveCard, addCard, updateCardDescription } from '@/app/actions'
 
 interface BoardState {
   todo: KanbanItem[]
@@ -17,7 +18,40 @@ interface BoardClientProps {
 
 export default function BoardClient({ initialData }: BoardClientProps) {
   const [columns, setColumns] = useState<BoardState>(initialData)
+  const [selectedCard, setSelectedCard] = useState<KanbanItem | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
   const [, startTransition] = useTransition()
+
+  const handleCardClick = (card: KanbanItem) => {
+    setSelectedCard(card)
+    setIsModalOpen(true)
+  }
+
+  const handleUpdateDescription = async (cardId: string, description: string) => {
+    // Update local state
+    setColumns(prev => {
+      const newState = { ...prev }
+      for (const columnKey of Object.keys(newState) as Array<keyof BoardState>) {
+        const cardIndex = newState[columnKey].findIndex(card => card.id === cardId)
+        if (cardIndex !== -1) {
+          newState[columnKey][cardIndex] = { 
+            ...newState[columnKey][cardIndex], 
+            description 
+          }
+          break
+        }
+      }
+      return newState
+    })
+
+    // Update selected card
+    if (selectedCard?.id === cardId) {
+      setSelectedCard({ ...selectedCard, description })
+    }
+
+    // Persist to database
+    await updateCardDescription(cardId, description)
+  }
 
   const handleAddCard = (content: string) => {
     const newCard: KanbanItem = {
@@ -70,28 +104,39 @@ export default function BoardClient({ initialData }: BoardClientProps) {
   }
 
   return (
-    <DndContext onDragEnd={handleDragEnd}>
-      <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-        <KanbanColumn 
-          id="todo"
-          title="Todo" 
-          accent="border-orange-500" 
-          items={columns.todo}
-          onAddCard={handleAddCard}
-        />
-        <KanbanColumn 
-          id="progress"
-          title="In Progress" 
-          accent="border-blue-500" 
-          items={columns.progress} 
-        />
-        <KanbanColumn 
-          id="done"
-          title="Done" 
-          accent="border-green-500" 
-          items={columns.done} 
-        />
-      </main>
-    </DndContext>
+    <>
+      <DndContext onDragEnd={handleDragEnd}>
+        <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
+          <KanbanColumn 
+            id="todo"
+            title="Todo" 
+            accent="border-orange-500" 
+            items={columns.todo}
+            onAddCard={handleAddCard}
+            onCardClick={handleCardClick}
+          />
+          <KanbanColumn 
+            id="progress"
+            title="In Progress" 
+            accent="border-blue-500" 
+            items={columns.progress}
+            onCardClick={handleCardClick}
+          />
+          <KanbanColumn 
+            id="done"
+            title="Done" 
+            accent="border-green-500" 
+            items={columns.done}
+            onCardClick={handleCardClick}
+          />
+        </main>
+      </DndContext>
+      <CardDetailModal
+        card={selectedCard}
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onUpdateDescription={handleUpdateDescription}
+      />
+    </>
   )
 }

--- a/src/components/CardDetailModal.tsx
+++ b/src/components/CardDetailModal.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog'
+import { KanbanItem } from './KanbanColumn'
+
+interface CardDetailModalProps {
+  card: KanbanItem | null
+  isOpen: boolean
+  onClose: () => void
+  onUpdateDescription: (cardId: string, description: string) => void
+}
+
+export default function CardDetailModal({
+  card,
+  isOpen,
+  onClose,
+  onUpdateDescription,
+}: CardDetailModalProps) {
+  const [description, setDescription] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (card) {
+      setDescription(card.description || '')
+    }
+  }, [card])
+
+  const handleDescriptionChange = async (value: string) => {
+    setDescription(value)
+    if (card) {
+      setIsSaving(true)
+      try {
+        await onUpdateDescription(card.id, value)
+      } finally {
+        setIsSaving(false)
+      }
+    }
+  }
+
+  if (!card) return null
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[550px]">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">{card.content}</DialogTitle>
+        </DialogHeader>
+        <div className="mt-4">
+          <label htmlFor="description" className="text-sm font-medium text-gray-700 block mb-2">
+            Description/Prompt
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => handleDescriptionChange(e.target.value)}
+            placeholder="Add a more detailed description..."
+            className="w-full min-h-[150px] p-3 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            disabled={isSaving}
+          />
+          {isSaving && (
+            <p className="text-sm text-gray-500 mt-1">Saving...</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -24,7 +24,7 @@ export default function KanbanCard({
     },
   })
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Only fire onClick if we're not dragging
     if (!isDragging && onClick) {
       onClick(e)

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -14,6 +14,7 @@ export default function KanbanCard({
   columnId,
   className,
   children,
+  onClick,
   ...props
 }: KanbanCardProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -23,11 +24,19 @@ export default function KanbanCard({
     },
   })
 
+  const handleClick = (e: React.MouseEvent) => {
+    // Only fire onClick if we're not dragging
+    if (!isDragging && onClick) {
+      onClick(e)
+    }
+  }
+
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
+      onClick={handleClick}
       className={cn(
         'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
         isDragging ? 'ring-2 ring-blue-500' : '',

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -7,6 +7,7 @@ import KanbanCard from './KanbanCard'
 export interface KanbanItem {
   id: string
   content: string
+  description?: string
 }
 
 interface KanbanColumnProps {
@@ -15,9 +16,10 @@ interface KanbanColumnProps {
   accent: string
   items: KanbanItem[]
   onAddCard?: (content: string) => void
+  onCardClick?: (card: KanbanItem) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items, onAddCard }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onAddCard, onCardClick }: KanbanColumnProps) {
   const [inputValue, setInputValue] = useState('')
   const { setNodeRef } = useDroppable({
     id: id,
@@ -60,7 +62,12 @@ export default function KanbanColumn({ id, title, accent, items, onAddCard }: Ka
           />
         )}
         {items.map((item) => (
-          <KanbanCard key={item.id} id={item.id} columnId={id}>
+          <KanbanCard 
+            key={item.id} 
+            id={item.id} 
+            columnId={id}
+            onClick={() => onCardClick?.(item)}
+          >
             {item.content}
           </KanbanCard>
         ))}


### PR DESCRIPTION
## Summary
- Clicking on a kanban card now opens a modal with the card details
- Added an editable description/prompt field that auto-saves as you type
- Descriptions persist in Redis and are restored on page reload

## Changes
- Updated `KanbanItem` interface to include optional `description` field
- Created new `CardDetailModal` component with auto-saving textarea
- Added `updateCardDescription` server action to persist description changes
- Modified card components to handle click events while preserving drag functionality
- Updated initial board data to include sample descriptions

## Test plan
- [x] Click on any card to open the modal
- [x] Type in the description field and verify it auto-saves
- [x] Close and reopen the modal to verify persistence
- [x] Refresh the page and check descriptions are retained
- [x] Verify drag and drop still works correctly
- [x] Test creating new cards (they should have empty descriptions)

🤖 Generated with [Claude Code](https://claude.ai/code)