### PR TITLE
Fix card tap deletion bug

### DIFF
--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { useState, useTransition, useEffect } from 'react'
-import { DndContext, DragEndEvent } from '@dnd-kit/core'
+import { 
+  DndContext, 
+  DragEndEvent, 
+  MouseSensor, 
+  TouchSensor, 
+  useSensor, 
+  useSensors 
+} from '@dnd-kit/core'
 import KanbanColumn, { KanbanItem } from './KanbanColumn'
 import CardDetailModal from './CardDetailModal'
 import { moveCard, addCard, updateCardDescription } from '@/app/actions'
@@ -23,6 +30,22 @@ export default function BoardClient({ initialData }: BoardClientProps) {
   const [selectedCard, setSelectedCard] = useState<KanbanItem | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [, startTransition] = useTransition()
+
+  // Configure sensors with activation constraints
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: {
+      distance: 10, // 10px of movement required to start drag
+    },
+  })
+
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: {
+      delay: 250, // 250ms press & hold to start drag
+      tolerance: 5, // 5px movement tolerance during delay
+    },
+  })
+
+  const sensors = useSensors(mouseSensor, touchSensor)
 
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
@@ -123,7 +146,7 @@ export default function BoardClient({ initialData }: BoardClientProps) {
 
   return (
     <>
-      <DndContext onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
         <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
           <KanbanColumn 
             id="todo"

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -25,8 +25,9 @@ export default function KanbanCard({
   })
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Only fire onClick if we're not dragging
+    // Prevent click during drag
     if (!isDragging && onClick) {
+      e.stopPropagation()
       onClick(e)
     }
   }
@@ -34,8 +35,8 @@ export default function KanbanCard({
   return (
     <div
       ref={setNodeRef}
-      {...listeners}
       {...attributes}
+      {...listeners}
       onClick={handleClick}
       className={cn(
         'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',


### PR DESCRIPTION
## Summary
- Fixed issue where tapping a kanban card could trigger unintended deletion
- Added proper activation constraints to distinguish between tap and drag gestures

## Changes
- Added `MouseSensor` with 10px distance threshold for desktop
  - Requires mouse to move 10 pixels before drag starts
- Added `TouchSensor` with 250ms delay for mobile
  - Requires tap-and-hold for 250ms to initiate drag
- Improved click event handling to prevent propagation issues
- Reordered event handler spread operators for proper precedence

## Test plan
- [x] Quick tap/click on card opens modal (no drag)
- [x] Dragging card requires deliberate gesture (10px movement or 250ms hold)
- [x] No cards are deleted on tap
- [x] Drag and drop functionality still works correctly
- [x] Works on both desktop and mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)