### PR TITLE
Implement Cult UI Expandable cards for Kanban cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,10 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@upstash/redis": "^1.35.0",
         "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
         "lucide-react": "^0.515.0",
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.3.1"
+        "react-dom": "^19.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -25,9 +23,12 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "clsx": "^2.1.1",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
-        "tailwindcss": "^4",
+        "framer-motion": "^12.18.1",
+        "tailwind-merge": "^3.3.1",
+        "tailwindcss": "^4.1.10",
         "typescript": "^5"
       }
     },
@@ -3772,6 +3773,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5062,6 +5091,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6252,6 +6298,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
       "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@upstash/redis": "^1.35.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "lucide-react": "^0.515.0",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -26,9 +24,12 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "clsx": "^2.1.1",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "tailwindcss": "^4",
+    "framer-motion": "^12.18.1",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.1.10",
     "typescript": "^5"
   }
 }

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
+import { Expandable, ExpandableCard, ExpandableContent } from './ui/expandable'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string
   columnId: string
+  description?: string
 }
 
 export default function KanbanCard({
@@ -14,9 +16,11 @@ export default function KanbanCard({
   columnId,
   className,
   children,
+  description,
   onClick,
   ...props
 }: KanbanCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: id,
     data: {
@@ -26,26 +30,42 @@ export default function KanbanCard({
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Prevent click during drag
-    if (!isDragging && onClick) {
+    if (!isDragging) {
       e.stopPropagation()
-      onClick(e)
+      setIsExpanded(!isExpanded)
+      onClick?.(e)
     }
   }
 
   return (
-    <div
-      ref={setNodeRef}
-      {...attributes}
-      {...listeners}
-      onClick={handleClick}
-      className={cn(
-        'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-transform hover:-translate-y-0.5 active:translate-y-0 cursor-grab',
-        isDragging ? 'ring-2 ring-blue-500' : '',
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
+    <Expandable expanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)}>
+      <ExpandableCard
+        className={cn(
+          'bg-white border border-neutral-300 rounded-xl px-4 py-3 text-sm hover:shadow transition-all duration-300 hover:-translate-y-0.5 active:translate-y-0',
+          isDragging ? 'ring-2 ring-blue-500 cursor-grabbing' : 'cursor-pointer',
+          isExpanded ? 'shadow-md' : '',
+          className
+        )}
+      >
+        <div
+          ref={setNodeRef}
+          {...attributes}
+          {...listeners}
+          onClick={handleClick}
+          {...props}
+        >
+          <div className="select-none">{children}</div>
+          
+          <ExpandableContent isExpanded={isExpanded}>
+            {description && (
+              <div className="text-sm text-neutral-600 border-t border-neutral-200 pt-2 mt-2">
+                <p className="font-medium text-xs text-neutral-500 mb-1">Details:</p>
+                <p className="whitespace-pre-wrap">{description}</p>
+              </div>
+            )}
+          </ExpandableContent>
+        </div>
+      </ExpandableCard>
+    </Expandable>
   )
 }

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -66,6 +66,7 @@ export default function KanbanColumn({ id, title, accent, items, onAddCard, onCa
             key={item.id} 
             id={item.id} 
             columnId={id}
+            description={item.description}
             onClick={() => onCardClick?.(item)}
           >
             {item.content}

--- a/src/components/ui/expandable.tsx
+++ b/src/components/ui/expandable.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import React, { useState, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { cn } from '@/lib/utils'
+
+interface ExpandableProps {
+  children: React.ReactNode | ((props: { isExpanded: boolean; toggle: () => void }) => React.ReactNode)
+  expanded?: boolean
+  onToggle?: () => void
+  className?: string
+}
+
+export function Expandable({
+  children,
+  expanded,
+  onToggle,
+  className
+}: ExpandableProps) {
+  const [internalExpanded, setInternalExpanded] = useState(false)
+
+  const isControlled = expanded !== undefined
+  const currentExpanded = isControlled ? expanded : internalExpanded
+
+  const handleToggle = useCallback(() => {
+    if (!isControlled) {
+      setInternalExpanded(prev => !prev)
+    }
+    onToggle?.()
+  }, [isControlled, onToggle])
+
+  return (
+    <div className={className}>
+      {typeof children === 'function' 
+        ? children({ isExpanded: currentExpanded, toggle: handleToggle })
+        : children
+      }
+    </div>
+  )
+}
+
+interface ExpandableCardProps {
+  children: React.ReactNode
+  className?: string
+  onClick?: () => void
+}
+
+export function ExpandableCard({ children, className, onClick }: ExpandableCardProps) {
+  return (
+    <div 
+      className={cn(
+        'transition-all duration-300 ease-out cursor-pointer',
+        className
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface ExpandableContentProps {
+  children: React.ReactNode
+  isExpanded: boolean
+  className?: string
+}
+
+export function ExpandableContent({ children, isExpanded, className }: ExpandableContentProps) {
+  return (
+    <AnimatePresence>
+      {isExpanded && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ 
+            duration: 0.3,
+            ease: 'easeOut'
+          }}
+          className={cn('overflow-hidden', className)}
+        >
+          <div className="pt-2">
+            {children}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,3 +2,4 @@ export * from "./button";
 export * from "./card";
 export * from "./input";
 export * from "./dialog";
+export * from "./expandable";


### PR DESCRIPTION
## Summary
- Implemented Cult UI expandable cards for the Kanban board with tap-to-expand functionality
- Cards now smoothly expand to show description details when tapped
- Added proper TypeScript types and drag prevention during expansion

## Changes
- Created new `expandable.tsx` component based on Cult UI design patterns
- Updated `KanbanCard` to use the expandable functionality
- Added `description` prop to cards and passed it from columns
- Implemented smooth animations with Framer Motion
- Prevented card expansion during drag operations
- Added visual feedback (shadow) when cards are expanded

## Test plan
- [x] Cards expand/collapse when tapped
- [x] Expansion animation is smooth
- [x] Description content is shown when expanded
- [x] Cards cannot expand while being dragged
- [x] TypeScript build passes
- [x] ESLint passes
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)