### PR TITLE
Fix card deletion on tap

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -35,6 +35,10 @@ export async function moveCard(
     return
   }
 
+  if (fromColumnId === toColumnId) {
+    return
+  }
+
   console.log(`Moving card ${cardId} from ${fromColumnId} to ${toColumnId}`)
 
   try {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
-    
+
     if (!over || active.id === over.id) {
       return
     }
@@ -67,6 +67,10 @@ export default function Home() {
     const cardId = active.id as string
     const fromColumnId = active.data.current?.columnId as string
     const toColumnId = over.id as string
+
+    if (fromColumnId === toColumnId) {
+      return
+    }
 
     setColumns((prev) => {
       let moved: KanbanItem | undefined
@@ -88,6 +92,7 @@ export default function Home() {
       return { ...next }
     })
 
+    // Persist to database only if the card moved columns
     startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -111,7 +111,7 @@ export default function BoardClient({ initialData }: BoardClientProps) {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
-    
+
     if (!over || active.id === over.id) {
       return
     }
@@ -119,6 +119,10 @@ export default function BoardClient({ initialData }: BoardClientProps) {
     const cardId = active.id as string
     const fromColumnId = active.data.current?.columnId as string
     const toColumnId = over.id as string
+
+    if (fromColumnId === toColumnId) {
+      return
+    }
 
     setColumns((prev) => {
       let moved: KanbanItem | undefined
@@ -140,7 +144,7 @@ export default function BoardClient({ initialData }: BoardClientProps) {
       return { ...next }
     })
 
-    // Persist to database
+    // Persist to database only if the card moved columns
     startTransition(() => moveCard(cardId, fromColumnId, toColumnId))
   }
 


### PR DESCRIPTION
## Summary
- prevent drag end handler from removing cards when dropped on the same column
- stop server action when source and target columns are equal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e0f6978ac832995eb7aaa98c50fdc