### PR TITLE
Fix disappearing cards on touch

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,30 +59,30 @@ export default function Home() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
-    
-    if (!over || active.id === over.id) {
-      return
-    }
 
     const cardId = active.id as string
     const fromColumnId = active.data.current?.columnId as string
-    const toColumnId = over.id as string
+    const toColumnId = (over?.id as string) ?? fromColumnId
 
     setColumns((prev) => {
       let moved: KanbanItem | undefined
       const next: BoardState = { ...prev }
-      
+
       // Find and remove the card from its current column
       const fromColumn = fromColumnId as keyof BoardState
       const idx = next[fromColumn].findIndex((i) => i.id === cardId)
       if (idx !== -1) {
         moved = next[fromColumn].splice(idx, 1)[0]
       }
-      
+
       // Add the card to the target column
       const toColumn = toColumnId as keyof BoardState
-      if (moved && fromColumn !== toColumn) {
-        next[toColumn].push(moved)
+      if (moved) {
+        if (fromColumn === toColumn) {
+          next[toColumn].splice(idx, 0, moved)
+        } else {
+          next[toColumn].push(moved)
+        }
       }
       
       return { ...next }

--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -111,30 +111,30 @@ export default function BoardClient({ initialData }: BoardClientProps) {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
-    
-    if (!over || active.id === over.id) {
-      return
-    }
 
     const cardId = active.id as string
     const fromColumnId = active.data.current?.columnId as string
-    const toColumnId = over.id as string
+    const toColumnId = (over?.id as string) ?? fromColumnId
 
     setColumns((prev) => {
       let moved: KanbanItem | undefined
       const next: BoardState = { ...prev }
-      
+
       // Find and remove the card from its current column
       const fromColumn = fromColumnId as keyof BoardState
       const idx = next[fromColumn].findIndex((i) => i.id === cardId)
       if (idx !== -1) {
         moved = next[fromColumn].splice(idx, 1)[0]
       }
-      
+
       // Add the card to the target column
       const toColumn = toColumnId as keyof BoardState
-      if (moved && fromColumn !== toColumn) {
-        next[toColumn].push(moved)
+      if (moved) {
+        if (fromColumn === toColumn) {
+          next[toColumn].splice(idx, 0, moved)
+        } else {
+          next[toColumn].push(moved)
+        }
       }
       
       return { ...next }


### PR DESCRIPTION
## Summary
- ensure moved cards are always reinserted, even when dropped on their original column
- reinsert cards at their prior index when dropped back on the same column

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e0f6978ac832995eb7aaa98c50fdc