### PR TITLE
Add inline description editing

### DIFF
--- a/src/components/BoardClient.tsx
+++ b/src/components/BoardClient.tsx
@@ -148,27 +148,30 @@ export default function BoardClient({ initialData }: BoardClientProps) {
     <>
       <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
         <main className="container mx-auto py-8 grid grid-cols-1 sm:grid-cols-3 gap-4 font-sans">
-          <KanbanColumn 
+          <KanbanColumn
             id="todo"
-            title="Todo" 
-            accent="border-orange-500" 
+            title="Todo"
+            accent="border-orange-500"
             items={columns.todo}
             onAddCard={handleAddCard}
             onCardClick={handleCardClick}
+            onUpdateDescription={handleUpdateDescription}
           />
-          <KanbanColumn 
+          <KanbanColumn
             id="progress"
-            title="In Progress" 
-            accent="border-blue-500" 
+            title="In Progress"
+            accent="border-blue-500"
             items={columns.progress}
             onCardClick={handleCardClick}
+            onUpdateDescription={handleUpdateDescription}
           />
-          <KanbanColumn 
+          <KanbanColumn
             id="done"
-            title="Done" 
-            accent="border-green-500" 
+            title="Done"
+            accent="border-green-500"
             items={columns.done}
             onCardClick={handleCardClick}
+            onUpdateDescription={handleUpdateDescription}
           />
         </main>
       </DndContext>

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -1,14 +1,16 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useDraggable } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
 import { Expandable, ExpandableCard, ExpandableContent } from './ui/expandable'
+import { Input } from './ui/input'
 
 export interface KanbanCardProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string
   columnId: string
   description?: string
+  onUpdateDescription?: (cardId: string, description: string) => void
 }
 
 export default function KanbanCard({
@@ -17,10 +19,12 @@ export default function KanbanCard({
   className,
   children,
   description,
+  onUpdateDescription,
   onClick,
   ...props
 }: KanbanCardProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [descInput, setDescInput] = useState('')
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: id,
     data: {
@@ -28,12 +32,29 @@ export default function KanbanCard({
     },
   })
 
+  useEffect(() => {
+    if (description) {
+      setDescInput('')
+    }
+  }, [description])
+
+  const handleSave = () => {
+    const trimmed = descInput.trim()
+    if (trimmed) {
+      onUpdateDescription?.(id, trimmed)
+      setDescInput('')
+    }
+    setIsExpanded(false)
+  }
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Prevent click during drag
     if (!isDragging) {
       e.stopPropagation()
       setIsExpanded(!isExpanded)
-      onClick?.(e)
+      if (description) {
+        onClick?.(e)
+      }
     }
   }
 
@@ -57,11 +78,26 @@ export default function KanbanCard({
           <div className="select-none">{children}</div>
           
           <ExpandableContent isExpanded={isExpanded}>
-            {description && (
+            {description ? (
               <div className="text-sm text-neutral-600 border-t border-neutral-200 pt-2 mt-2">
                 <p className="font-medium text-xs text-neutral-500 mb-1">Details:</p>
                 <p className="whitespace-pre-wrap">{description}</p>
               </div>
+            ) : (
+              <Input
+                autoFocus
+                placeholder="Add a description..."
+                value={descInput}
+                onChange={(e) => setDescInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleSave()
+                  }
+                }}
+                onBlur={handleSave}
+                className="mt-2 text-sm"
+              />
             )}
           </ExpandableContent>
         </div>

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -17,9 +17,10 @@ interface KanbanColumnProps {
   items: KanbanItem[]
   onAddCard?: (content: string) => void
   onCardClick?: (card: KanbanItem) => void
+  onUpdateDescription?: (cardId: string, description: string) => void
 }
 
-export default function KanbanColumn({ id, title, accent, items, onAddCard, onCardClick }: KanbanColumnProps) {
+export default function KanbanColumn({ id, title, accent, items, onAddCard, onCardClick, onUpdateDescription }: KanbanColumnProps) {
   const [inputValue, setInputValue] = useState('')
   const { setNodeRef } = useDroppable({
     id: id,
@@ -62,11 +63,12 @@ export default function KanbanColumn({ id, title, accent, items, onAddCard, onCa
           />
         )}
         {items.map((item) => (
-          <KanbanCard 
-            key={item.id} 
-            id={item.id} 
+          <KanbanCard
+            key={item.id}
+            id={item.id}
             columnId={id}
             description={item.description}
+            onUpdateDescription={onUpdateDescription}
             onClick={() => onCardClick?.(item)}
           >
             {item.content}


### PR DESCRIPTION
## Summary
- allow expanding cards without a description to show an input
- propagate update handler through board and columns

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e143198e483298caa369c71bb18a3