### PR TITLE
feat: Add hardcoded description to all kanban cards

### DIFF
--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -16,7 +16,6 @@ export default function KanbanCard({
   columnId,
   className,
   children,
-  description,
   onClick,
   ...props
 }: KanbanCardProps) {
@@ -57,12 +56,10 @@ export default function KanbanCard({
           <div className="select-none">{children}</div>
           
           <ExpandableContent isExpanded={isExpanded}>
-            {description && (
-              <div className="text-sm text-neutral-600 border-t border-neutral-200 pt-2 mt-2">
-                <p className="font-medium text-xs text-neutral-500 mb-1">Details:</p>
-                <p className="whitespace-pre-wrap">{description}</p>
-              </div>
-            )}
+            <div className="text-sm text-neutral-600 border-t border-neutral-200 pt-2 mt-2">
+              <p className="font-medium text-xs text-neutral-500 mb-1">Details:</p>
+              <p className="whitespace-pre-wrap">Create a new branch for this feature. Implement it, create Tests when relevant, run no test and fix any broken tests, give me a summary of what was done, update Claude.md with anything relevant for future development (but be picky and brief), make a PR, monitor the PR&apos;s tests, if they fail fix them and try again, if they succeed let me know the branch is safe to be merged.</p>
+            </div>
           </ExpandableContent>
         </div>
       </ExpandableCard>

--- a/src/components/__tests__/KanbanCard.test.tsx
+++ b/src/components/__tests__/KanbanCard.test.tsx
@@ -64,7 +64,7 @@ describe('KanbanCard', () => {
 
     // Description should now be visible
     expect(screen.getByText('Details:')).toBeInTheDocument()
-    expect(screen.getByText('Test description')).toBeInTheDocument()
+    expect(screen.getByText('Create a new branch for this feature. Implement it, create Tests when relevant, run no test and fix any broken tests, give me a summary of what was done, update Claude.md with anything relevant for future development (but be picky and brief), make a PR, monitor the PR\'s tests, if they fail fix them and try again, if they succeed let me know the branch is safe to be merged.')).toBeInTheDocument()
   })
 
   it('applies dragging styles when being dragged', () => {


### PR DESCRIPTION
## Summary
- Updated KanbanCard component to display a fixed description for all cards
- Updated corresponding test to match the new hardcoded description
- Removed unused `description` prop to fix linting errors

## Test plan
- [x] Updated KanbanCard test passes
- [x] ESLint passes without errors
- [x] Component displays hardcoded description when expanded

🤖 Generated with [Claude Code](https://claude.ai/code)